### PR TITLE
Add support for more extensions

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2,7 +2,7 @@
  * Parse Google Docs files to retrieve their edit link and redirect to it
  */
 
-const GOOGLE_DOCS_EXTENSIONS = [".gddoc", ".gdlink", ".gdsheets", ".gdslides"];
+const GOOGLE_DOCS_EXTENSIONS = [".gddoc", ".gdlink", ".gdsheets", ".gdslides", ".gdoc", ".glink", ".gform", ".gsheet", ".gslides"];
 
 $("#fileList").click((event) => {
   const fileLink = $(event.target).closest("a.name");


### PR DESCRIPTION
For some reason Google seems to use both gd* and g* prefixes to docs, slides, sheets and link files. Might be a localization thing, a regional thing, or simply a change at some point in time but the truth is that if you look it up there's both, though more commonly the g* prefix it seems. 

Adding support for that prefix, and also gform (Google Forms).

Tested it on my end and seems to work as intended.