### PR TITLE
Update element identification for NC25

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -4,7 +4,7 @@
 
 const GOOGLE_DOCS_EXTENSIONS = [".gddoc", ".gdlink", ".gdsheets", ".gdslides"];
 
-$("#fileList").click((event) => {
+$(".files-fileList").click((event) => {
   const fileLink = $(event.target).closest("a.name");
   const extension = fileLink.find(".extension").text();
 


### PR DESCRIPTION
On NC25 (at least) the previous selector of #filesList was no longer available. The equivalent is now .files-fileList .

Unsure how this can be added so that it supports different NC versions - does it get published as a different version in the store? I imagine we'd need to update the app info to support nc25, but this change doesn't work in previous versions, so I'd appreciate some guidance here.

Thanks.