### PR TITLE
Remove broken navigation in top menu

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,10 +16,4 @@
     <dependencies>
         <nextcloud min-version="17" max-version="22"/>
     </dependencies>
-    <navigations>
-        <navigation>
-            <name>Google Docs Redirect</name>
-            <route>googledocsredirect.page.index</route>
-        </navigation>
-    </navigations>
 </info>


### PR DESCRIPTION
In NC25 the app forces a top-level navigation icon that is both broken and doesn't seem to lead anywhere? I'm removing it here, but maybe there's a different solution for it to accomplish what it was originally intended to, which I'm not aware of what it was.

Please feel free to reject this change, or edit it as appropriate.

Thanks!